### PR TITLE
docs: record brand position in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,24 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 The Ultimate Star Wars Timeline — a React app that renders an interactive, scrollable timeline of Star Wars characters, movies, TV shows, and eras (High Republic Era through New Jedi Order, roughly -300 BBY to 50 ABY). Live at https://timeline.starwars.guide/.
 
+## Brand position (read before changing anything user-facing)
+
+This repo is a **satellite app** in the AurebeshFiles brand. The hub is **`../starwars-guide`** (starwars.guide) — the Jekyll landing site that introduces, cross-links, and indexes every app.
+
+**`../starwars-guide/CLAUDE.md` is the source of truth for the brand as a whole**: the full sibling-repo map, branding, navigation, SEO conventions, social handles, and cross-app links are all decided there. Read it before any change that affects how this app is presented, named, or linked.
+
+Division of ownership:
+
+- **This repo owns**: the timeline app itself — data, interactions, visuals, its own deploy (GitHub Pages from `docs/`).
+- **starwars-guide owns**: the product name in marketing copy, the `/star-wars-timeline` landing page, the home-page app card, nav placement, social handles, and the `WebApplication` JSON-LD for this product.
+
+**This repo writes content into the hub.** `build_scripts/website.js` generates `character/*.md` plus images directly into `../starwars-guide` (sibling checkout required). Those files are **generated — never hand-edited in starwars-guide**; fixes belong here. Two known open items live on this side:
+
+- Character front matter emits `social-desc: "Name  | Star Wars"`, which becomes the Google snippet and OG card for ~80 pages. It needs real per-character description text.
+- Generated event markup starts at `<h4>`, so hub pages skip a heading level. The hub's `_layouts/character.html` injects an `h2` to soften it, but the real fix is here.
+
+Changing the shape of that generated output (front matter keys, heading levels, file naming) is a **cross-repo change** — check the hub's `_layouts/character.html` and `_includes/structured-data.html` before shipping it.
+
 ## Commands
 
 Run from the repo root (`starwars-timeline/`):


### PR DESCRIPTION
Adds a **Brand position** section to `CLAUDE.md`, above `## Commands`.

`starwars-guide` (starwars.guide) is the hub for the AurebeshFiles brand — it introduces, cross-links and indexes every app. Its `CLAUDE.md` is now marked as the source of truth for branding, navigation, SEO conventions, social handles and cross-app links, so future agents don't re-decide those here.

Repo-specific content beyond that:

- **Ownership split** — this repo owns the timeline app and its GH Pages deploy; the hub owns the product name in marketing copy, `/star-wars-timeline`, the home-page card, nav placement, and the `WebApplication` JSON-LD.
- **This repo writes into the hub.** `build_scripts/website.js` generates `character/*.md` + images into `../starwars-guide`. Those are generated files — fixes belong here, not downstream.
- **Two open defects named**, both living on this side:
  - character front matter emits `social-desc: "Name  | Star Wars"`, which is the Google snippet and OG card for ~80 hub pages;
  - generated event markup starts at `<h4>`, so hub pages skip a heading level (the hub's `character.html` injects an `h2` to soften it).
- Changing the shape of generated output is flagged as a cross-repo change.

Docs only — no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NjAkPJCBHLDnbeXTHt4sgN